### PR TITLE
Support FASTA File Exports

### DIFF
--- a/orfaqs/lib/python/core/aminoacids.py
+++ b/orfaqs/lib/python/core/aminoacids.py
@@ -455,10 +455,17 @@ class AminoAcidSequence(Sequence):
         self,
         sequence: (AminoAcid | list[AminoAcid] | str) = None,
         name: str = None,
+        uid: str = None,
+        info: str = None,
     ):
         if isinstance(sequence, AminoAcid):
             sequence = [sequence]
-        super().__init__(sequence=sequence, name=name)
+        super().__init__(
+            sequence=sequence,
+            name=name,
+            uid=uid,
+            info=info,
+        )
 
     @property
     def amino_acid_chain(self) -> list[AminoAcid]:

--- a/orfaqs/lib/python/core/nucleotides.py
+++ b/orfaqs/lib/python/core/nucleotides.py
@@ -152,12 +152,16 @@ class GenomicSequence(Sequence):
         sequence: (str | list[str] | list[NucleicAcid]),
         strand_type: StrandType = None,
         name: str = None,
+        uid: str = None,
+        info: str = None,
         log_errors: bool = True,
         raise_errors: bool = True,
     ):
         super().__init__(
             sequence=sequence,
             name=name,
+            uid=uid,
+            info=info,
             log_errors=log_errors,
             raise_errors=raise_errors,
         )
@@ -294,14 +298,8 @@ class NucleotideUtils:
                     raise_errors=raise_errors,
                 )
             except ValueError as e:
-                message = (
-                    '[ERROR] The sequence could not be interpreted as '
-                    'a DNA sequence or an RNA sequence. Check the '
-                    'input for errors.'
-                )
-                _logger.error(message)
                 if raise_errors:
-                    raise ValueError(message) from e
+                    raise ValueError from e
 
     @staticmethod
     def is_dna_sequence(

--- a/orfaqs/lib/python/core/proteins.py
+++ b/orfaqs/lib/python/core/proteins.py
@@ -19,9 +19,16 @@ class Protein(AminoAcidSequence):
         self,
         sequence: (AminoAcid | list[AminoAcid] | str) = None,
         name: str = None,
+        uid: str = None,
+        info: str = None,
         sequence_complete: bool = False,
     ):
-        super().__init__(sequence=sequence, name=name)
+        super().__init__(
+            sequence=sequence,
+            name=name,
+            uid=uid,
+            info=info,
+        )
 
         self._sequence_complete = sequence_complete
         if isinstance(sequence, Protein):

--- a/orfaqs/lib/python/core/sequence.py
+++ b/orfaqs/lib/python/core/sequence.py
@@ -13,11 +13,15 @@ class Sequence(abc.ABC):
         self,
         sequence: (str | list),
         name: str,
+        uid: str = None,
+        info: str = None,
         log_errors: bool = True,
         raise_errors: bool = True,
     ):
         self._sequence_str: str = ''
         self._name = name
+        self._uid = uid
+        self._info = info
         if isinstance(sequence, list):
             sequence = ''.join(list(map(str, sequence)))
 
@@ -68,6 +72,14 @@ class Sequence(abc.ABC):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def uid(self) -> str:
+        return self._uid
+
+    @property
+    def info(self) -> str:
+        return self._info
 
     @property
     def sequence_str(self) -> str:

--- a/orfaqs/lib/python/utils/fastautils.py
+++ b/orfaqs/lib/python/utils/fastautils.py
@@ -67,6 +67,10 @@ def _write_fasta_str_to_file(
     return file_path
 
 
+class FASTAExportFormat:
+    FASTA = _fasta_extension_type_to_str(FASTAFileExtensionType.FASTA)
+
+
 class FASTASequence:
     """FASTASequence"""
 
@@ -309,8 +313,7 @@ class FASTAUtils:
                 sequence_str: str = None
                 if isinstance(input_sequence, Sequence):
                     sequence_str = input_sequence.sequence_str
-                    if info is None:
-                        info = input_sequence.name
+                    uid = input_sequence.uid
                 elif isinstance(input_sequence, str):
                     sequence_str = input_sequence
 

--- a/orfaqs/modules/python/common/orfaqscli.py
+++ b/orfaqs/modules/python/common/orfaqscli.py
@@ -114,13 +114,6 @@ class ORFaqsCli(ABC):
         )
 
     @staticmethod
-    def _default_callback_kwargs() -> dict[str, any]:
-        return {
-            'invoke_without_command': True,
-            'context_settings': {'allow_interspersed_args': True},
-        }
-
-    @staticmethod
     def _job_id_annotation() -> tuple:
         return (
             str,

--- a/orfaqs/modules/python/orfaqsproteindiscovery/apps/orfaqs_protein_discovery.py
+++ b/orfaqs/modules/python/orfaqsproteindiscovery/apps/orfaqs_protein_discovery.py
@@ -27,7 +27,10 @@ class ORFaqsProteinDiscoveryCli(ORFaqsCli):
     def program_name():
         return 'ORFaqs Protein Discovery'
 
-    @app.callback(**ORFaqsCli._default_callback_kwargs())
+    @app.callback(
+        invoke_without_command=True,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def discover_proteins(
         input_sequence: Annotated[

--- a/orfaqs/modules/python/orfaqsproteinquery/apps/orfaqs_protein_query.py
+++ b/orfaqs/modules/python/orfaqsproteinquery/apps/orfaqs_protein_query.py
@@ -113,7 +113,10 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
             table=table,
         )
 
-    @app.command(Commands.LOAD_PROTEINS.value)
+    @app.command(
+        Commands.LOAD_PROTEINS.value,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def load_proteins(
         proteins: Annotated[
@@ -165,7 +168,10 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
         if query_result is not None:
             PandasUtils.print_dataframe(query_result)
 
-    @app.command(Commands.QUERY.value)
+    @app.command(
+        Commands.QUERY.value,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def query_proteins(
         query: Annotated[_query_annotation(typer.Argument)] = None,
@@ -218,7 +224,10 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
             query=query,
         )
 
-    @app.command(Commands.EXPORT.value)
+    @app.command(
+        Commands.EXPORT.value,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def export_proteins(
         workspace: Annotated[_workspace_annotation(typer.Option)] = None,
@@ -249,7 +258,10 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
             all_workspaces=all_workspaces,
         )
 
-    @app.command(Commands.REMOVE_WORKSPACES.value)
+    @app.command(
+        Commands.REMOVE_WORKSPACES.value,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def remove_workspaces(
         workspaces: Annotated[
@@ -289,7 +301,10 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
             all_tables=all_tables,
         )
 
-    @app.command(Commands.REMOVE_TABLES.value)
+    @app.command(
+        Commands.REMOVE_TABLES.value,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def remove_tables(
         workspace: Annotated[_workspace_annotation(typer.Argument)] = None,
@@ -325,7 +340,10 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
             all_workspaces_and_tables=all_workspaces_and_tables,
         )
 
-    @app.command(Commands.SHOW.value)
+    @app.command(
+        Commands.SHOW.value,
+        context_settings={'allow_interspersed_args': True},
+    )
     @staticmethod
     def show(
         workspace: Annotated[
@@ -380,7 +398,7 @@ class ORFaqsProteinQueryCli(ORFaqsCli):
             ctx['all_workspaces_and_tables'] = ctx.params.pop('all')
             ORFaqsProteinQueryCli.show(**ctx.params)
 
-    @app.callback(**ORFaqsCli._default_callback_kwargs())
+    @app.callback(invoke_without_command=True)
     @staticmethod
     def cli(
         launch_json: Annotated[ORFaqsCli._launch_json_annotation()] = None,

--- a/orfaqs/modules/python/orfaqsproteinquery/orfaqsproteinquery.py
+++ b/orfaqs/modules/python/orfaqsproteinquery/orfaqsproteinquery.py
@@ -8,6 +8,8 @@ import pandas as pd
 import pathlib
 import typing
 
+from orfaqs.lib.python.core.proteins import Protein
+
 from orfaqs.modules.python.common.orfaqsapi import ORFaqsApi
 
 from orfaqs.modules.python.orfaqsproteindiscovery.orfaqsproteindiscovery import (
@@ -34,6 +36,7 @@ from orfaqs.lib.python.utils.databaseutils import (
 )
 from orfaqs.lib.python.utils.directoryutils import DirectoryUtils
 from orfaqs.lib.python.utils.fastautils import (
+    FASTAExportFormat,
     FASTASequenceType,
     FASTAUtils,
 )
@@ -48,6 +51,7 @@ _logger = logging.getLogger(__name__)
 _ExportFormatOptions = typing.Literal[
     DataFrameExportFormat.CSV,
     DataFrameExportFormat.XLSX,
+    FASTAExportFormat.FASTA,
 ]
 _AVAILABLE_EXPORT_FORMATS: list[str] = [
     format for format in _ExportFormatOptions.__args__
@@ -130,7 +134,9 @@ class ORFaqsProteinQueryApi(ORFaqsApi):
         proteins_dataframe: pd.DataFrame,
     ):
         def create_uid(row: pd.Series):
-            uid = row[ORFaqsDiscoveredProteinsTableSchema.SOURCE_UID_KEY]
+            source_uid = row[
+                ORFaqsDiscoveredProteinsTableSchema.SOURCE_UID_KEY
+            ]
             strand_type = row[
                 ORFaqsDiscoveredProteinsTableSchema.STRAND_TYPE_KEY
             ]
@@ -144,7 +150,7 @@ class ORFaqsProteinQueryApi(ORFaqsApi):
                 ORFaqsDiscoveredProteinsTableSchema.PROTEIN_LENGTH_KEY
             ]
             return ORFaqsProteinQueryApi._create_uid(
-                uid=uid,
+                uid=source_uid,
                 strand_type=strand_type,
                 reading_frame=reading_frame,
                 rna_sequence_position=rna_sequence_position,
@@ -391,12 +397,30 @@ class ORFaqsProteinQueryApi(ORFaqsApi):
         dataframe: pd.DataFrame,
         export_format: _ExportFormatOptions = None,
     ):
-        ORFaqsProteinQueryApi._prepare_dataframe_for_export(dataframe)
-        PandasUtils.export_dataframe(
-            file_path=file_path,
-            dataframe=dataframe,
-            export_format=export_format,
-        )
+        if FASTAExportFormat.FASTA == export_format:
+            # Create a list of Protein seqences
+            protein_sequences: list[Protein] = []
+
+            def _fill_protein_sequence_list(row: pd.Series):
+                protein_sequences.append(
+                    Protein(
+                        sequence=row[ORFaqsProteinRecord.PROTEIN_KEY],
+                        uid=row[ORFaqsProteinRecord.UID_KEY],
+                    )
+                )
+
+            dataframe.apply(_fill_protein_sequence_list, axis='columns')
+            FASTAUtils.export_as_fasta_file(
+                file_path=file_path,
+                sequences=protein_sequences,
+            )
+        else:
+            ORFaqsProteinQueryApi._prepare_dataframe_for_export(dataframe)
+            PandasUtils.export_dataframe(
+                file_path=file_path,
+                dataframe=dataframe,
+                export_format=export_format,
+            )
 
     @staticmethod
     def _export_proteins(


### PR DESCRIPTION
Adding support for FASTA file exports. Now Sequence objects can take optional uid and info parameters. The query tool also supports fasta exports in all commands where protein exports are expected.